### PR TITLE
Enable RLS policies and privacy-aware analytics

### DIFF
--- a/db/migrations/0001_enable_rls.sql
+++ b/db/migrations/0001_enable_rls.sql
@@ -1,0 +1,13 @@
+-- Enable Row Level Security on user-owned tables
+ALTER TABLE trips ENABLE ROW LEVEL SECURITY;
+ALTER TABLE opal_uploads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE settings ENABLE ROW LEVEL SECURITY;
+
+-- Only allow access to rows owned by the authenticated user
+CREATE POLICY trips_owner ON trips
+    USING (user_id = auth.uid());
+CREATE POLICY opal_uploads_owner ON opal_uploads
+    USING (user_id = auth.uid());
+CREATE POLICY settings_owner ON settings
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());

--- a/db/migrations/0002_privacy_settings.sql
+++ b/db/migrations/0002_privacy_settings.sql
@@ -1,0 +1,4 @@
+-- Add privacy and metrics configuration options
+ALTER TABLE settings
+    ADD COLUMN collect_metrics boolean DEFAULT true,
+    ADD COLUMN share_anonymized_metrics boolean DEFAULT true;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = global.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma;

--- a/src/pages/api/analytics.ts
+++ b/src/pages/api/analytics.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { prisma } from '../../lib/prisma';
+import { authOptions } from './auth/options';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { user_id } = req.query;
+  if (user_id !== session.user.id) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const settings = await prisma.settings.findUnique({
+    where: { user_id: session.user.id },
+  });
+
+  if (!settings?.collect_metrics) {
+    return res.status(204).end();
+  }
+
+  const stats = await prisma.trips.aggregate({
+    where: { user_id: session.user.id },
+    _sum: { fare: true, duration_minutes: true },
+  });
+
+  if (settings.share_anonymized_metrics) {
+    // placeholder for sending anonymized metrics to an external collector
+  }
+
+  return res.status(200).json({
+    totalFare: stats._sum.fare ?? 0,
+    totalMinutes: stats._sum.duration_minutes ?? 0,
+  });
+}

--- a/src/pages/api/auth/options.ts
+++ b/src/pages/api/auth/options.ts
@@ -1,0 +1,2 @@
+// Placeholder auth options for NextAuth
+export const authOptions = {} as const;

--- a/src/pages/api/trips.ts
+++ b/src/pages/api/trips.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { prisma } from '../../lib/prisma';
+import { authOptions } from '../auth/options';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { user_id } = req.query;
+  if (user_id !== session.user.id) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const trips = await prisma.trips.findMany({
+    where: { user_id: session.user.id },
+  });
+
+  return res.status(200).json(trips);
+}


### PR DESCRIPTION
## Summary
- enable row level security and ownership policies for user tables
- guard API routes with session user id checks
- add privacy flags to settings and honour them in analytics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade0a454d08329a9ab7f210afb5908