### PR TITLE
feat(web): add core pages and layout

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Nav from './Nav';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <Nav />
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/components/Nav.tsx
+++ b/apps/web/src/components/Nav.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import React from 'react';
+
+export default function Nav() {
+  return (
+    <nav>
+      <ul>
+        <li><Link href="/onboarding">Onboarding</Link></li>
+        <li><Link href="/uploads">Uploads</Link></li>
+        <li><Link href="/dashboard">Dashboard</Link></li>
+        <li><Link href="/live">Live Departures</Link></li>
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,0 +1,15 @@
+import type { AppProps } from 'next/app';
+import React, { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Layout from '../components/Layout';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  const [queryClient] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+export default function DashboardPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['summary'],
+    queryFn: () => fetch('/api/stats/summary').then((res) => res.json()),
+  });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      {data && (
+        <div>
+          <p>Trips: {data.trips}</p>
+          <p>Distance: {data.distance}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/live.tsx
+++ b/apps/web/src/pages/live.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+export default function LivePage() {
+  const [stopId, setStopId] = useState('');
+  const query = useQuery({
+    queryKey: ['departures', stopId],
+    queryFn: () => fetch(`/api/live/departures?stopId=${stopId}`).then((res) => res.json()),
+    enabled: !!stopId,
+  });
+
+  return (
+    <div>
+      <h1>Live Departures</h1>
+      <input value={stopId} onChange={(e) => setStopId(e.target.value)} placeholder="Stop ID" />
+      <button onClick={() => query.refetch()} disabled={!stopId}>
+        Load
+      </button>
+      {query.data && <pre>{JSON.stringify(query.data.departures, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/apps/web/src/pages/onboarding.tsx
+++ b/apps/web/src/pages/onboarding.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+export default function OnboardingPage() {
+  const { data } = useQuery({
+    queryKey: ['summary'],
+    queryFn: () => fetch('/api/stats/summary').then((res) => res.json()),
+  });
+
+  return (
+    <div>
+      <h1>Onboarding</h1>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}

--- a/apps/web/src/pages/uploads.tsx
+++ b/apps/web/src/pages/uploads.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+
+export default function UploadsPage() {
+  const [content, setContent] = useState('');
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/opal/upload', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+      return res.json();
+    },
+  });
+
+  return (
+    <div>
+      <h1>Uploads</h1>
+      <textarea value={content} onChange={(e) => setContent(e.target.value)} />
+      <button onClick={() => mutation.mutate()}>Upload</button>
+      {mutation.data && <pre>{JSON.stringify(mutation.data, null, 2)}</pre>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement shared Layout and Nav components
- add onboarding, uploads, dashboard, and live departure pages wired to API routes via TanStack Query
- configure QueryClient provider in `_app`

## Testing
- `npm test`
