### PR TITLE
Integrate Prisma and Transport NSW API in web handlers

### DIFF
--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = global.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma;

--- a/apps/web/src/pages/api/live/alerts.ts
+++ b/apps/web/src/pages/api/live/alerts.ts
@@ -1,8 +1,13 @@
 import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
+import { getAlerts } from '../../../lib/transportNSW';
 
 export const config = { runtime: 'edge' };
 
+const querySchema = z.object({
+  routeId: z.string(),
+  line: z.string().optional(),
+});
 const responseSchema = z.object({ alerts: z.array(z.any()) });
 
 export default async function handler(req: Request): Promise<Response> {
@@ -11,14 +16,23 @@ export default async function handler(req: Request): Promise<Response> {
   }
   try {
     await requireUser(req);
-    const alerts: any[] = [];
+    const { searchParams } = new URL(req.url);
+    const query = querySchema.parse(Object.fromEntries(searchParams));
+    const alerts = await getAlerts(query.routeId, query.line);
     return new Response(
       JSON.stringify(responseSchema.parse({ alerts })),
       { status: 200, headers: { 'content-type': 'application/json' } }
     );
   } catch (err: any) {
-    return err instanceof Response
-      ? err
-      : new Response('Bad Request', { status: 400 });
+    if (err instanceof Response) return err;
+    const status =
+      typeof err.message === 'string' &&
+      (err.message.includes('Transport NSW') ||
+        err.message.includes('circuit breaker'))
+        ? 503
+        : 400;
+    return new Response(status === 503 ? 'Service Unavailable' : 'Bad Request', {
+      status,
+    });
   }
 }

--- a/apps/web/src/pages/api/live/departures.ts
+++ b/apps/web/src/pages/api/live/departures.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
+import { getDepartures } from '../../../lib/transportNSW';
 
 export const config = { runtime: 'edge' };
 
-const querySchema = z.object({ stopId: z.string() });
+const querySchema = z.object({
+  stopId: z.string(),
+  limit: z.coerce.number().optional(),
+});
 const responseSchema = z.object({ departures: z.array(z.any()) });
 
 export default async function handler(req: Request): Promise<Response> {
@@ -14,14 +18,21 @@ export default async function handler(req: Request): Promise<Response> {
     await requireUser(req);
     const { searchParams } = new URL(req.url);
     const query = querySchema.parse(Object.fromEntries(searchParams));
-    const departures: any[] = [];
+    const departures = await getDepartures(query.stopId, query.limit);
     return new Response(
       JSON.stringify(responseSchema.parse({ departures })),
       { status: 200, headers: { 'content-type': 'application/json' } }
     );
   } catch (err: any) {
-    return err instanceof Response
-      ? err
-      : new Response('Bad Request', { status: 400 });
+    if (err instanceof Response) return err;
+    const status =
+      typeof err.message === 'string' &&
+      (err.message.includes('Transport NSW') ||
+        err.message.includes('circuit breaker'))
+        ? 503
+        : 400;
+    return new Response(status === 503 ? 'Service Unavailable' : 'Bad Request', {
+      status,
+    });
   }
 }

--- a/apps/web/src/pages/api/trips/[id].ts
+++ b/apps/web/src/pages/api/trips/[id].ts
@@ -1,23 +1,41 @@
 import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
+import { prisma } from '../../../lib/prisma';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const paramsSchema = z.object({ id: z.string() });
-const bodySchema = z.object({ name: z.string().optional() });
-const responseSchema = z.object({ id: z.string(), updated: z.boolean() });
+const bodySchema = z.object({
+  notes: z.string().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+});
+const tripSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+  })
+  .passthrough();
+const responseSchema = tripSchema;
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== 'PATCH') {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    const user = await requireUser(req);
     const id = new URL(req.url).pathname.split('/').pop() || '';
     paramsSchema.parse({ id });
     const body = bodySchema.parse(await req.json());
+
+    const existing = await prisma.trip.findUnique({ where: { id } });
+    if (!existing || existing.userId !== user.id) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const trip = await prisma.trip.update({ where: { id }, data: body });
+
     return new Response(
-      JSON.stringify(responseSchema.parse({ id, updated: true })),
+      JSON.stringify(responseSchema.parse(trip)),
       { status: 200, headers: { 'content-type': 'application/json' } }
     );
   } catch (err: any) {

--- a/apps/web/src/pages/api/trips/index.ts
+++ b/apps/web/src/pages/api/trips/index.ts
@@ -1,10 +1,17 @@
 import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
+import { prisma } from '../../../lib/prisma';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const querySchema = z.object({ limit: z.string().optional() });
-const responseSchema = z.object({ trips: z.array(z.any()) });
+const tripSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+  })
+  .passthrough();
+const responseSchema = z.object({ trips: z.array(tripSchema) });
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== 'GET') {
@@ -14,7 +21,12 @@ export default async function handler(req: Request): Promise<Response> {
     const user = await requireUser(req);
     const { searchParams } = new URL(req.url);
     const query = querySchema.parse(Object.fromEntries(searchParams));
-    const trips: any[] = [];
+    const limit = query.limit ? parseInt(query.limit, 10) : undefined;
+    const trips = await prisma.trip.findMany({
+      where: { userId: user.id },
+      orderBy: { tapOnTime: 'desc' },
+      ...(limit ? { take: limit } : {}),
+    });
     return new Response(
       JSON.stringify(responseSchema.parse({ trips })),
       { status: 200, headers: { 'content-type': 'application/json' } }


### PR DESCRIPTION
## Summary
- use Prisma to fetch and update user trips
- wire departures and alerts endpoints to Transport NSW API with circuit-breaker handling
- add shared Prisma client for web app

## Testing
- `npm test`

