### PR TITLE
feat: integrate nextauth session

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,9 +1,13 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../pages/api/auth/[...nextauth]';
+
 export interface User {
   id: string;
 }
 
-export async function requireUser(req: Request): Promise<User> {
-  const id = req.headers.get('x-user-id');
+export async function requireUser(): Promise<User> {
+  const session = await getServerSession(authOptions);
+  const id = (session?.user as any)?.id;
   if (!id) {
     throw new Response('Unauthorized', { status: 401 });
   }

--- a/apps/web/src/pages/api/auth/[...nextauth].ts
+++ b/apps/web/src/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,19 @@
+import NextAuth, { type NextAuthOptions } from 'next-auth';
+import EmailProvider from 'next-auth/providers/email';
+import GoogleProvider from 'next-auth/providers/google';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    EmailProvider({
+      server: process.env.EMAIL_SERVER,
+      from: process.env.EMAIL_FROM,
+    }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+};
+
+export default NextAuth(authOptions);

--- a/apps/web/src/pages/api/live/alerts.ts
+++ b/apps/web/src/pages/api/live/alerts.ts
@@ -10,7 +10,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    await requireUser();
     const alerts: any[] = [];
     return new Response(
       JSON.stringify(responseSchema.parse({ alerts })),

--- a/apps/web/src/pages/api/live/departures.ts
+++ b/apps/web/src/pages/api/live/departures.ts
@@ -11,7 +11,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    await requireUser();
     const { searchParams } = new URL(req.url);
     const query = querySchema.parse(Object.fromEntries(searchParams));
     const departures: any[] = [];

--- a/apps/web/src/pages/api/opal/parse/[uploadId].ts
+++ b/apps/web/src/pages/api/opal/parse/[uploadId].ts
@@ -11,7 +11,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    await requireUser();
     const { searchParams, pathname } = new URL(req.url);
     const uploadId = pathname.split('/').pop() || '';
     paramsSchema.parse({ uploadId });

--- a/apps/web/src/pages/api/opal/upload.ts
+++ b/apps/web/src/pages/api/opal/upload.ts
@@ -11,7 +11,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    const user = await requireUser(req);
+    const user = await requireUser();
     const body = bodySchema.parse(await req.json());
     const uploadId = `${user.id}-${Date.now()}`;
     return new Response(

--- a/apps/web/src/pages/api/stats/heatmap.ts
+++ b/apps/web/src/pages/api/stats/heatmap.ts
@@ -14,7 +14,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    await requireUser();
     const points: any[] = [];
     return new Response(
       JSON.stringify(responseSchema.parse({ points })),

--- a/apps/web/src/pages/api/stats/summary.ts
+++ b/apps/web/src/pages/api/stats/summary.ts
@@ -10,7 +10,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    await requireUser();
     const stats = { trips: 0, distance: 0 };
     return new Response(
       JSON.stringify(responseSchema.parse(stats)),

--- a/apps/web/src/pages/api/trips/[id].ts
+++ b/apps/web/src/pages/api/trips/[id].ts
@@ -12,7 +12,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
+    await requireUser();
     const id = new URL(req.url).pathname.split('/').pop() || '';
     paramsSchema.parse({ id });
     const body = bodySchema.parse(await req.json());

--- a/apps/web/src/pages/api/trips/index.ts
+++ b/apps/web/src/pages/api/trips/index.ts
@@ -11,7 +11,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    const user = await requireUser(req);
+    const user = await requireUser();
     const { searchParams } = new URL(req.url);
     const query = querySchema.parse(Object.fromEntries(searchParams));
     const trips: any[] = [];


### PR DESCRIPTION
## Summary
- add NextAuth config with Google and Email providers
- read user from NextAuth session in `requireUser`
- update API routes to use session-based user IDs

## Testing
- `npm test`


