### PR TITLE
Implement pre-signed upload and parsing workflow

### DIFF
--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -1,0 +1,82 @@
+import { createHmac, createHash } from 'crypto';
+
+const ENDPOINT = process.env.STORAGE_ENDPOINT || '';
+const ACCESS_KEY_ID = process.env.STORAGE_ACCESS_KEY_ID || '';
+const SECRET_ACCESS_KEY = process.env.STORAGE_SECRET_ACCESS_KEY || '';
+const BUCKET = process.env.STORAGE_BUCKET || '';
+const REGION = process.env.STORAGE_REGION || 'ap-southeast-2';
+
+function hash(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function hmac(key: string | Buffer, data: string): Buffer {
+  return createHmac('sha256', key).update(data).digest();
+}
+
+function hmacHex(key: string | Buffer, data: string): string {
+  return createHmac('sha256', key).update(data).digest('hex');
+}
+
+function presign(method: string, key: string, expires = 3600, contentType?: string): string {
+  if (!ENDPOINT || !ACCESS_KEY_ID || !SECRET_ACCESS_KEY || !BUCKET) {
+    throw new Error('storage not configured');
+  }
+  const url = new URL(`${ENDPOINT.replace(/\/$/, '')}/${BUCKET}/${key}`);
+  const host = url.host;
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  const dateStamp = amzDate.slice(0, 8);
+  const scope = `${dateStamp}/${REGION}/s3/aws4_request`;
+  const credential = `${ACCESS_KEY_ID}/${scope}`;
+
+  const headers: string[] = [`host:${host}`];
+  if (contentType && method === 'PUT') {
+    headers.push(`content-type:${contentType}`);
+  }
+  const signedHeaders = headers.map(h => h.split(':')[0]).join(';');
+  const canonicalHeaders = headers.join('\n') + '\n';
+
+  const query = new URLSearchParams({
+    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+    'X-Amz-Credential': credential,
+    'X-Amz-Date': amzDate,
+    'X-Amz-Expires': String(expires),
+    'X-Amz-SignedHeaders': signedHeaders
+  });
+
+  const canonicalRequest = [
+    method,
+    url.pathname,
+    query.toString(),
+    canonicalHeaders,
+    signedHeaders,
+    'UNSIGNED-PAYLOAD'
+  ].join('\n');
+
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    scope,
+    hash(canonicalRequest)
+  ].join('\n');
+
+  const kDate = hmac('AWS4' + SECRET_ACCESS_KEY, dateStamp);
+  const kRegion = hmac(kDate, REGION);
+  const kService = hmac(kRegion, 's3');
+  const kSigning = hmac(kService, 'aws4_request');
+  const signature = hmacHex(kSigning, stringToSign);
+
+  query.set('X-Amz-Signature', signature);
+  return `${url.toString()}?${query.toString()}`;
+}
+
+export function presignUpload(key: string, contentType: string): string {
+  return presign('PUT', key, 3600, contentType);
+}
+
+export function presignDownload(key: string, expires = 3600): string {
+  return presign('GET', key, expires);
+}
+
+export { BUCKET };

--- a/apps/web/src/pages/api/opal/parse/[uploadId].ts
+++ b/apps/web/src/pages/api/opal/parse/[uploadId].ts
@@ -1,23 +1,68 @@
 import { z } from 'zod';
 import { requireUser } from '../../../../lib/auth';
+import { PrismaClient } from '@prisma/client';
+import { presignDownload } from '../../../../lib/storage';
+import { inngest } from '../../../../jobs';
 
 export const config = { runtime: 'edge' };
 
+const prisma = new PrismaClient();
+
 const paramsSchema = z.object({ uploadId: z.string() });
-const responseSchema = z.object({ parsed: z.boolean() });
+const bodySchema = z.object({ type: z.enum(['csv', 'html']) });
+const warningSchema = z.object({ index: z.number(), message: z.string() });
+const responseSchema = z.object({ uploadId: z.string(), rowsParsed: z.number(), warnings: z.array(warningSchema) });
 
 export default async function handler(req: Request): Promise<Response> {
-  if (req.method !== 'GET') {
+  if (req.method !== 'POST') {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-    await requireUser(req);
-    const { searchParams, pathname } = new URL(req.url);
+    const user = await requireUser(req);
+    const { pathname } = new URL(req.url);
     const uploadId = pathname.split('/').pop() || '';
     paramsSchema.parse({ uploadId });
-    const parsed = true;
+    const body = bodySchema.parse(await req.json());
+
+    const upload = await prisma.opalUpload.findFirst({ where: { id: uploadId, userId: user.id } });
+    if (!upload) {
+      return new Response('Not Found', { status: 404 });
+    }
+    const key = `${user.id}/${uploadId}/${upload.filename}`;
+    const fileUrl = presignDownload(key);
+    const rawRes = await fetch(fileUrl);
+    const raw = await rawRes.text();
+
+    const parser = await import('../../../../../../../packages/opal-parser/src');
+    const parseFn = body.type === 'html' ? parser.parseHTML : parser.parseCSV;
+    const { records, warnings } = parseFn(raw, {});
+
+    if (records.length) {
+      await prisma.trip.createMany({
+        data: records.map((r: any) => ({
+          userId: user.id,
+          tapOnTime: r.tap_on_time ? new Date(r.tap_on_time) : null,
+          tapOffTime: r.tap_off_time ? new Date(r.tap_off_time) : null,
+          mode: r.line || null,
+          line: r.line || null,
+          originName: r.from_stop || null,
+          destName: r.to_stop || null,
+          fareCents: r.fare_cents ?? null,
+          defaultFare: r.is_default_fare ?? false,
+          source: uploadId,
+        })),
+      });
+    }
+
+    await prisma.opalUpload.update({
+      where: { id: uploadId },
+      data: { status: 'parsed', rowsParsed: records.length },
+    });
+
+    await inngest.send({ name: 'statements/uploaded', data: { fileUrl } });
+
     return new Response(
-      JSON.stringify(responseSchema.parse({ parsed })),
+      JSON.stringify(responseSchema.parse({ uploadId, rowsParsed: records.length, warnings })),
       { status: 200, headers: { 'content-type': 'application/json' } }
     );
   } catch (err: any) {

--- a/apps/web/src/pages/api/opal/upload.ts
+++ b/apps/web/src/pages/api/opal/upload.ts
@@ -1,10 +1,14 @@
 import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
+import { presignUpload } from '../../../lib/storage';
+import { PrismaClient } from '@prisma/client';
 
 export const config = { runtime: 'edge' };
 
-const bodySchema = z.object({ content: z.string() });
-const responseSchema = z.object({ uploadId: z.string() });
+const prisma = new PrismaClient();
+
+const bodySchema = z.object({ filename: z.string(), mime: z.string() });
+const responseSchema = z.object({ uploadId: z.string(), url: z.string() });
 
 export default async function handler(req: Request): Promise<Response> {
   if (req.method !== 'POST') {
@@ -13,9 +17,21 @@ export default async function handler(req: Request): Promise<Response> {
   try {
     const user = await requireUser(req);
     const body = bodySchema.parse(await req.json());
-    const uploadId = `${user.id}-${Date.now()}`;
+    const uploadId = crypto.randomUUID();
+    const key = `${user.id}/${uploadId}/${body.filename}`;
+    const url = presignUpload(key, body.mime);
+    await prisma.opalUpload.create({
+      data: {
+        id: uploadId,
+        userId: user.id,
+        filename: body.filename,
+        mime: body.mime,
+        status: 'pending',
+        rowsParsed: 0,
+      },
+    });
     return new Response(
-      JSON.stringify(responseSchema.parse({ uploadId })),
+      JSON.stringify(responseSchema.parse({ uploadId, url })),
       { status: 200, headers: { 'content-type': 'application/json' } }
     );
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- Generate S3 pre-signed URLs for Opal uploads and persist upload metadata
- Parse uploaded Opal statements, store trips, surface warnings, and trigger background job
- Add helper for AWS Signature V4 presigned URL generation

## Testing
- `npm test`

