### PR TITLE
Fetch and return alerts

### DIFF
--- a/apps/web/src/pages/api/__tests__/live.test.ts
+++ b/apps/web/src/pages/api/__tests__/live.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../../../lib/transportNSW', () => ({
   getAlerts: vi.fn().mockResolvedValue([]),
@@ -7,6 +7,7 @@ vi.mock('../../../lib/transportNSW', () => ({
 
 import alertsHandler from '../live/alerts';
 import departuresHandler from '../live/departures';
+import { getAlerts } from '../../../lib/transportNSW';
 
 const base = 'http://localhost';
 
@@ -17,6 +18,14 @@ describe('GET /api/live/alerts', () => {
     expect(res.status).toBe(401);
   });
 
+  it('validates query params', async () => {
+    const req = new Request(`${base}/api/live/alerts`, {
+      headers: { 'x-user-id': 'user1' }
+    });
+    const res = await alertsHandler(req);
+    expect(res.status).toBe(400);
+  });
+
   it('rejects unsupported methods', async () => {
     const req = new Request(`${base}/api/live/alerts`, { method: 'POST' });
     const res = await alertsHandler(req);
@@ -24,12 +33,35 @@ describe('GET /api/live/alerts', () => {
   });
 
   it('returns alerts for authenticated user', async () => {
-    const req = new Request(`${base}/api/live/alerts`, {
+    const req = new Request(`${base}/api/live/alerts?routeId=1&line=T1`, {
       headers: { 'x-user-id': 'user1' }
     });
     const res = await alertsHandler(req);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ alerts: [] });
+    expect(getAlerts).toHaveBeenCalledWith('1', 'T1');
+  });
+
+  it('returns 503 when service fails', async () => {
+    vi.mocked(getAlerts).mockRejectedValueOnce(
+      new Error('Transport NSW API error: 500')
+    );
+    const req = new Request(`${base}/api/live/alerts?routeId=1`, {
+      headers: { 'x-user-id': 'user1' }
+    });
+    const res = await alertsHandler(req);
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 when circuit breaker is open', async () => {
+    vi.mocked(getAlerts).mockRejectedValueOnce(
+      new Error('Transport NSW API circuit breaker open')
+    );
+    const req = new Request(`${base}/api/live/alerts?routeId=1`, {
+      headers: { 'x-user-id': 'user1' }
+    });
+    const res = await alertsHandler(req);
+    expect(res.status).toBe(503);
   });
 });
 

--- a/apps/web/src/pages/api/live/alerts.ts
+++ b/apps/web/src/pages/api/live/alerts.ts
@@ -15,8 +15,11 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-      await requireUser(req);
-    const alerts: any[] = [];
+    await requireUser(req);
+    const { routeId, line } = querySchema.parse(
+      Object.fromEntries(new URL(req.url).searchParams)
+    );
+    const alerts = await getAlerts(routeId, line);
     return new Response(
       JSON.stringify(responseSchema.parse({ alerts })),
       { status: 200, headers: { 'content-type': 'application/json' } }

--- a/apps/web/src/pages/api/stats/summary.ts
+++ b/apps/web/src/pages/api/stats/summary.ts
@@ -15,8 +15,8 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-      await requireUser(req);
-    const stats = { trips: 0, distance: 0 };
+    await requireUser(req);
+    const stats = { trips: 0, distance: 0, fare: 0 };
 
     return new Response(
       JSON.stringify(responseSchema.parse(stats)),


### PR DESCRIPTION
## Summary
- Parse and validate `routeId`/`line` query params in live alerts API and fetch real alerts
- Ensure stats summary response includes fare to satisfy schema
- Add comprehensive tests for alerts endpoint success and failure scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bec481e6c08329a979038bb174dbb9