### PR TITLE
feat: parse opal statements with shared parser

### DIFF
--- a/apps/web/src/jobs/__tests__/parseStatements.test.ts
+++ b/apps/web/src/jobs/__tests__/parseStatements.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { createMany, uploadUpdate } = vi.hoisted(() => ({
+  createMany: vi.fn(),
+  uploadUpdate: vi.fn()
+}));
 
 vi.mock('../client', () => ({
   inngest: {
@@ -10,28 +15,63 @@ vi.mock('../../utils/cache', () => ({
   cache: { clear: vi.fn() }
 }));
 
+vi.mock('@prisma/client', () => ({
+  PrismaClient: vi.fn(() => ({
+    trip: { createMany },
+    opalUpload: { update: uploadUpdate }
+  }))
+}));
+
 import { cache } from '../../utils/cache';
 import { parseStatements } from '../parseStatements';
 
 describe('parseStatements job', () => {
-  it('parses statements and clears cache', async () => {
-    const file = '2024-01-01,A,10\n2024-01-02,B,20\n';
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMany.mockResolvedValue(undefined);
+    uploadUpdate.mockResolvedValue(undefined);
+  });
+
+  it('parses statements, persists trips, updates upload and clears cache', async () => {
+    const file = 'Tap On,Tap Off,Mode,From Stop,To Stop,Fare\n2024-01-01 10:00,2024-01-01 10:30,Train,T1,T2,$2.50\n';
     global.fetch = vi.fn().mockResolvedValue({ text: () => Promise.resolve(file) }) as any;
 
-    const run = vi
-      .fn()
-      .mockImplementationOnce((_name, fn) => fn())
-      .mockImplementationOnce((_name, fn) => fn());
+    const run = vi.fn((_name, fn) => fn());
 
     const result = await parseStatements.fn({
-      event: { data: { fileUrl: 'http://example.com/file.csv' } },
+      event: { data: { fileUrl: 'http://example.com/file.csv', uploadId: 'u1', userId: 'user1', type: 'csv' } },
       step: { run }
     });
 
     expect(fetch).toHaveBeenCalledWith('http://example.com/file.csv');
-    expect(run.mock.calls[0][0]).toBe('download');
-    expect(run.mock.calls[1][0]).toBe('save');
-    expect(result).toEqual({ parsed: 2 });
+    expect(createMany).toHaveBeenCalledTimes(1);
+    expect(uploadUpdate).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { status: 'parsed', rowsParsed: 1 }
+    });
     expect(cache.clear).toHaveBeenCalledWith('statements');
+    expect(result).toEqual({ parsed: 1 });
+  });
+
+  it('does not clear cache when persistence fails', async () => {
+    const file = 'Tap On,Tap Off,Mode,From Stop,To Stop,Fare\n2024-01-01 10:00,2024-01-01 10:30,Train,T1,T2,$2.50\n';
+    global.fetch = vi.fn().mockResolvedValue({ text: () => Promise.resolve(file) }) as any;
+
+    createMany.mockRejectedValueOnce(new Error('db fail'));
+
+    const run = vi.fn((_name, fn) => fn());
+
+    await expect(
+      parseStatements.fn({
+        event: { data: { fileUrl: 'http://example.com/file.csv', uploadId: 'u1', userId: 'user1', type: 'csv' } },
+        step: { run }
+      })
+    ).rejects.toThrow('db fail');
+
+    expect(cache.clear).not.toHaveBeenCalled();
+    expect(uploadUpdate).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { status: 'error' }
+    });
   });
 });

--- a/apps/web/src/pages/api/stats/summary.ts
+++ b/apps/web/src/pages/api/stats/summary.ts
@@ -16,7 +16,7 @@ export default async function handler(req: Request): Promise<Response> {
   }
   try {
       await requireUser(req);
-    const stats = { trips: 0, distance: 0 };
+    const stats = { trips: 0, distance: 0, fare: 0 };
 
     return new Response(
       JSON.stringify(responseSchema.parse(stats)),


### PR DESCRIPTION
## Summary
- parse statement uploads with shared opal-parser and persist trips with Prisma
- update upload status and clear caches only after successful save
- fix stats summary endpoint to include fare

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bec48330f88329878e87f4ade21948