### PR TITLE
feat: implement file upload flow and display parsing results

### DIFF
--- a/apps/web/src/pages/uploads.tsx
+++ b/apps/web/src/pages/uploads.tsx
@@ -1,25 +1,63 @@
 import React, { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 
+interface ParseResponse {
+  uploadId: string;
+  rowsParsed: number;
+  warnings: { index: number; message: string }[];
+}
+
 export default function UploadsPage() {
-  const [content, setContent] = useState('');
-  const mutation = useMutation({
-    mutationFn: async () => {
+  const [file, setFile] = useState<File | null>(null);
+  const mutation = useMutation<ParseResponse, unknown, File>({
+    mutationFn: async (file: File) => {
       const res = await fetch('/api/opal/upload', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ content }),
+        body: JSON.stringify({ filename: file.name, mime: file.type }),
       });
-      return res.json();
+      const { uploadId, url } = await res.json();
+
+      await fetch(url, {
+        method: 'PUT',
+        headers: { 'content-type': file.type },
+        body: file,
+      });
+
+      const type = file.name.toLowerCase().endsWith('.html') ? 'html' : 'csv';
+      const parseRes = await fetch(`/api/opal/parse/${uploadId}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ type }),
+      });
+      return parseRes.json();
     },
   });
 
   return (
     <div>
       <h1>Uploads</h1>
-      <textarea value={content} onChange={(e) => setContent(e.target.value)} />
-      <button onClick={() => mutation.mutate()}>Upload</button>
-      {mutation.data && <pre>{JSON.stringify(mutation.data, null, 2)}</pre>}
+      <input type="file" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+      <button onClick={() => file && mutation.mutate(file)} disabled={!file || mutation.isLoading}>
+        Upload
+      </button>
+      {mutation.data && (
+        <div>
+          <p>Rows parsed: {mutation.data.rowsParsed}</p>
+          {mutation.data.warnings.length > 0 && (
+            <div>
+              <h2>Warnings</h2>
+              <ul>
+                {mutation.data.warnings.map((w) => (
+                  <li key={w.index}>
+                    {w.index}: {w.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace textarea with file input on uploads page
- request presigned URL, upload file, then parse and show results

## Testing
- `npm test` *(fails: GET /api/stats/summary returns 400 instead of 200)*

------
https://chatgpt.com/codex/tasks/task_e_68bec482b7e08329a229dd0ba96b0593