### PR TITLE
Aggregate trip stats for dashboard

### DIFF
--- a/apps/web/src/pages/api/__tests__/live.test.ts
+++ b/apps/web/src/pages/api/__tests__/live.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next-auth', () => ({
+  default: () => ({}),
+  getServerSession: vi.fn(),
+}), { virtual: true });
+vi.mock('next-auth/providers/email', () => ({ default: () => ({}) }), { virtual: true });
+vi.mock('next-auth/providers/google', () => ({ default: () => ({}) }), { virtual: true });
 
 vi.mock('../../../lib/transportNSW', () => ({
   getAlerts: vi.fn().mockResolvedValue([]),
@@ -30,6 +37,7 @@ describe('GET /api/live/alerts', () => {
     const req = new Request(`${base}/api/live/alerts`, {
       headers: { 'x-user-id': 'user1' }
     });
+    getServerSessionMock.mockResolvedValueOnce({ user: { id: 'user1' } } as any);
     const res = await alertsHandler(req);
     expect(res.status).toBe(400);
   });
@@ -44,6 +52,7 @@ describe('GET /api/live/alerts', () => {
     const req = new Request(`${base}/api/live/alerts?routeId=1&line=T1`, {
       headers: { 'x-user-id': 'user1' }
     });
+    getServerSessionMock.mockResolvedValueOnce({ user: { id: 'user1' } } as any);
     const res = await alertsHandler(req);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ alerts: [] });
@@ -57,6 +66,7 @@ describe('GET /api/live/alerts', () => {
     const req = new Request(`${base}/api/live/alerts?routeId=1`, {
       headers: { 'x-user-id': 'user1' }
     });
+    getServerSessionMock.mockResolvedValueOnce({ user: { id: 'user1' } } as any);
     const res = await alertsHandler(req);
     expect(res.status).toBe(503);
   });
@@ -68,6 +78,7 @@ describe('GET /api/live/alerts', () => {
     const req = new Request(`${base}/api/live/alerts?routeId=1`, {
       headers: { 'x-user-id': 'user1' }
     });
+    getServerSessionMock.mockResolvedValueOnce({ user: { id: 'user1' } } as any);
     const res = await alertsHandler(req);
     expect(res.status).toBe(503);
   });

--- a/apps/web/src/pages/api/__tests__/stats.test.ts
+++ b/apps/web/src/pages/api/__tests__/stats.test.ts
@@ -7,6 +7,48 @@ vi.mock('next-auth', () => ({
 vi.mock('next-auth/providers/email', () => ({ default: () => ({}) }), { virtual: true });
 vi.mock('next-auth/providers/google', () => ({ default: () => ({}) }), { virtual: true });
 
+vi.mock('../../../lib/prisma', () => {
+  const trips = [
+    {
+      userId: 'user1',
+      distanceKm: 5,
+      fareCents: 300,
+      originLat: -33.87,
+      originLng: 151.21,
+      destLat: -33.88,
+      destLng: 151.22,
+    },
+    {
+      userId: 'user1',
+      distanceKm: 7.5,
+      fareCents: 400,
+      originLat: -33.87,
+      originLng: 151.21,
+      destLat: -33.86,
+      destLng: 151.2,
+    },
+  ];
+
+  return {
+    prisma: {
+      trip: {
+        aggregate: vi.fn(async ({ where }: any) => {
+          const userTrips = trips.filter((t) => t.userId === where.userId);
+          const distance = userTrips.reduce((sum, t) => sum + (t.distanceKm ?? 0), 0);
+          const fare = userTrips.reduce((sum, t) => sum + (t.fareCents ?? 0), 0);
+          return {
+            _count: { _all: userTrips.length },
+            _sum: { distanceKm: distance, fareCents: fare },
+          };
+        }),
+        findMany: vi.fn(async ({ where }: any) =>
+          trips.filter((t) => t.userId === where.userId)
+        ),
+      },
+    },
+  };
+});
+
 import { getServerSession } from 'next-auth';
 import summaryHandler from '../stats/summary';
 import heatmapHandler from '../stats/heatmap';

--- a/apps/web/src/pages/api/stats/summary.ts
+++ b/apps/web/src/pages/api/stats/summary.ts
@@ -15,9 +15,18 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response('Method Not Allowed', { status: 405 });
   }
   try {
-      await requireUser(req);
-    const stats = { trips: 0, distance: 0, fare: 0 };
+    const user = await requireUser(req);
+    const aggregation = await prisma.trip.aggregate({
+      where: { userId: user.id },
+      _count: { _all: true },
+      _sum: { distanceKm: true, fareCents: true },
+    });
 
+    const stats = {
+      trips: aggregation._count._all ?? 0,
+      distance: Number(aggregation._sum.distanceKm ?? 0),
+      fare: aggregation._sum.fareCents ?? 0,
+    };
 
     return new Response(
       JSON.stringify(responseSchema.parse(stats)),

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -18,6 +18,7 @@ export default function DashboardPage() {
         <div>
           <p>Trips: {data.trips}</p>
           <p>Distance: {data.distance}</p>
+          <p>Fare: {data.fare}</p>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Aggregate trip count, distance, and fare using Prisma for authenticated users
- Mock Prisma in stats API tests to return realistic totals
- Display trip, distance, and fare totals on dashboard
- Add NextAuth mocks to live API tests for consistency

## Testing
- `pnpm test`

