### PR TITLE
Persist GTFS archive and record hash

### DIFF
--- a/apps/web/src/jobs/refreshGtfs.ts
+++ b/apps/web/src/jobs/refreshGtfs.ts
@@ -1,5 +1,8 @@
 import { inngest } from "./client";
 import { cache } from "../utils/cache";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
 
 /**
  * Nightly job to refresh GTFS static data and invalidate caches.
@@ -10,18 +13,44 @@ export const refreshGtfs = inngest.createFunction(
   { cron: "0 2 * * *" },
   async ({ step }) => {
     const url = process.env.GTFS_URL || "";
+    const storageDir =
+      process.env.GTFS_STORAGE_DIR || path.join(process.cwd(), "db", "gtfs");
 
-    // Download latest GTFS archive
-    const data = await step.run("download", () => fetch(url).then(r => r.arrayBuffer()));
+    try {
+      // Download latest GTFS archive
+      const buffer = await step.run("download", async () => {
+        const res = await fetch(url);
+        return Buffer.from(await res.arrayBuffer());
+      });
 
-    // Persist archive somewhere (placeholder)
-    await step.run("store", async () => {
-      console.log(`retrieved ${data.byteLength} bytes of GTFS data`);
-    });
+      const hash = createHash("sha256").update(buffer).digest("hex");
 
-    // Invalidate caches
-    await cache.clear("gtfs");
+      // Persist archive to storage and record hash
+      await step.run("store", async () => {
+        try {
+          await fs.mkdir(storageDir, { recursive: true });
+          await fs.writeFile(path.join(storageDir, `${hash}.zip`), buffer);
+          await fs.writeFile(
+            path.join(storageDir, "latest.json"),
+            JSON.stringify({ hash }, null, 2)
+          );
+          console.info(
+            { bytes: buffer.byteLength, hash },
+            "gtfs archive persisted"
+          );
+        } catch (err) {
+          console.error({ err, hash }, "failed to persist gtfs archive");
+          throw err;
+        }
+      });
 
-    return { refreshed: true };
+      // Invalidate caches
+      await cache.clear("gtfs");
+
+      return { refreshed: true, hash };
+    } catch (err) {
+      console.error({ err }, "refresh GTFS job failed");
+      throw err;
+    }
   }
 );


### PR DESCRIPTION
## Summary
- persist nightly GTFS download to configurable storage and record its hash
- replace `console.log` with structured logging and error handling
- test GTFS refresh persists archive and clears cache

## Testing
- `npx vitest run src/jobs/__tests__/refreshGtfs.test.ts`
- `npm test` *(fails: Cannot find package 'next-auth'; Cannot find module '.prisma/client/default')*
