### PR TITLE
Pass request to NextAuth getServerSession

### DIFF
--- a/apps/web/src/lib/__tests__/auth.test.ts
+++ b/apps/web/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next-auth', () => ({
+  default: () => ({}),
+  getServerSession: vi.fn(),
+}), { virtual: true });
+vi.mock('next-auth/providers/email', () => ({ default: () => ({}) }), { virtual: true });
+vi.mock('next-auth/providers/google', () => ({ default: () => ({}) }), { virtual: true });
+
+import { getServerSession } from 'next-auth';
+import { requireUser } from '../auth';
+
+const getServerSessionMock = vi.mocked(getServerSession);
+
+describe('requireUser', () => {
+  const base = 'http://localhost';
+
+  beforeEach(() => {
+    getServerSessionMock.mockReset();
+  });
+
+  it('returns user when authenticated', async () => {
+    const req = new Request(`${base}/api/test`);
+    getServerSessionMock.mockResolvedValueOnce({ user: { id: 'user1' } } as any);
+
+    await expect(requireUser(req)).resolves.toEqual({ id: 'user1' });
+    expect(getServerSessionMock).toHaveBeenCalledWith(req, expect.any(Object));
+  });
+
+  it('throws 401 when unauthenticated', async () => {
+    const req = new Request(`${base}/api/test`);
+    getServerSessionMock.mockResolvedValueOnce(null);
+
+    await expect(requireUser(req)).rejects.toMatchObject({ status: 401 });
+    expect(getServerSessionMock).toHaveBeenCalledWith(req, expect.any(Object));
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -5,8 +5,8 @@ export interface User {
   id: string;
 }
 
-export async function requireUser(_req: Request): Promise<User> {
-  const session = await getServerSession(authOptions);
+export async function requireUser(req: Request): Promise<User> {
+  const session = await getServerSession(req, { ...authOptions });
   const id = session?.user?.id as string | undefined;
   if (!id) {
     throw new Response('Unauthorized', { status: 401 });

--- a/apps/web/src/pages/api/__tests__/stats.test.ts
+++ b/apps/web/src/pages/api/__tests__/stats.test.ts
@@ -11,6 +11,10 @@ vi.mock('../../../lib/prisma', () => ({
   prisma: {
     trip: {
       findMany: vi.fn().mockResolvedValue([]),
+      aggregate: vi.fn().mockResolvedValue({
+        _count: { _all: 0 },
+        _sum: { distanceKm: 0, fareCents: 0 },
+      }),
     },
   },
 }));


### PR DESCRIPTION
## Summary
- pass the incoming request to `getServerSession` and use spread auth options
- cover authenticated vs unauthenticated flows in `requireUser`
- fix stats tests by mocking Prisma aggregate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c53dd9857c8329a58c81cf9dc5dcf7