### PR TITLE
Use camelCase Trip column names in seed script

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -37,7 +37,7 @@ async function main() {
       const start = new Date(now - i * 86400000 + 8 * 3600000); // 8AM each day
       const end = new Date(start.getTime() + 45 * 60000); // 45 mins later
       await client.query(
-        `INSERT INTO trips (user_id, origin_stop_id, origin_lat, origin_lng, destination_stop_id, dest_lat, dest_lng, mode, start_time, end_time, fare_cents)
+        `INSERT INTO "Trip" ("userId", "originStopId", "originLat", "originLng", "destStopId", "destLat", "destLng", "mode", "tapOnTime", "tapOffTime", "fareCents")
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
         [
           userId,


### PR DESCRIPTION
## Summary
- Update seed script to use camelCase Trip column names like `originStopId` and `tapOnTime`

## Testing
- `npm test` *(fails: expected 200 to be 400)*
- `npm run seed` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c53dda67b88329b6535bc2f9734113