### PR TITLE
Switch API handlers to Node.js runtime

### DIFF
--- a/apps/web/src/pages/api/live/alerts.ts
+++ b/apps/web/src/pages/api/live/alerts.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
 import { getAlerts } from '../../../lib/transportNSW';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const querySchema = z.object({
   routeId: z.string(),

--- a/apps/web/src/pages/api/live/departures.ts
+++ b/apps/web/src/pages/api/live/departures.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
 import { getDepartures } from '../../../lib/transportNSW';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const querySchema = z.object({
   stopId: z.string(),

--- a/apps/web/src/pages/api/opal/parse/[uploadId].ts
+++ b/apps/web/src/pages/api/opal/parse/[uploadId].ts
@@ -4,7 +4,7 @@ import { PrismaClient } from '@prisma/client';
 import { presignDownload } from '../../../../lib/storage';
 import { inngest } from '../../../../jobs';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const prisma = new PrismaClient();
 

--- a/apps/web/src/pages/api/opal/upload.ts
+++ b/apps/web/src/pages/api/opal/upload.ts
@@ -3,7 +3,7 @@ import { requireUser } from '../../../lib/auth';
 import { presignUpload } from '../../../lib/storage';
 import { PrismaClient } from '@prisma/client';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const prisma = new PrismaClient();
 

--- a/apps/web/src/pages/api/stats/heatmap.ts
+++ b/apps/web/src/pages/api/stats/heatmap.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
 import { prisma } from '../../../lib/prisma';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const responseSchema = z.object({
   points: z.array(

--- a/apps/web/src/pages/api/stats/summary.ts
+++ b/apps/web/src/pages/api/stats/summary.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
 import { prisma } from '../../../lib/prisma';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 const responseSchema = z.object({
   trips: z.number(),


### PR DESCRIPTION
## Summary
- migrate API route handlers from edge to Node.js runtime
- keep Prisma usage compatible with Node.js environment

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next/link' and other type errors)*
- `pnpm test`
