### PR TITLE
refactor: reuse prisma client in opal handlers

### DIFF
--- a/apps/web/src/pages/api/__tests__/opal.upload.test.ts
+++ b/apps/web/src/pages/api/__tests__/opal.upload.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { create, PrismaClient } = vi.hoisted(() => ({
+  create: vi.fn(),
+  PrismaClient: vi.fn(() => ({ opalUpload: { create } })),
+}));
+
+vi.mock('../../../lib/auth', () => ({
+  requireUser: vi.fn(),
+}));
+
+vi.mock('../../../lib/storage', () => ({
+  presignUpload: vi.fn(),
+}));
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient,
+}));
+import { requireUser } from '../../../lib/auth';
+import { presignUpload } from '../../../lib/storage';
+
+const requireUserMock = vi.mocked(requireUser);
+const presignUploadMock = vi.mocked(presignUpload);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe('POST /api/opal/upload', () => {
+  it('reuses prisma connection across requests', async () => {
+    requireUserMock.mockResolvedValue({ id: 'user1' } as any);
+    presignUploadMock.mockReturnValue('http://upload');
+
+    (globalThis as any).prisma = undefined;
+    const { default: handler } = await import('../opal/upload');
+    const req = () =>
+      new Request('http://localhost/api/opal/upload', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ filename: 'file.csv', mime: 'text/csv' }),
+      });
+
+    const res1 = await handler(req());
+    const res2 = await handler(req());
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(PrismaClient).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/apps/web/src/pages/api/opal/parse/[uploadId].ts
+++ b/apps/web/src/pages/api/opal/parse/[uploadId].ts
@@ -1,12 +1,11 @@
 import { z } from 'zod';
 import { requireUser } from '../../../../lib/auth';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../../../../lib/prisma';
 import { presignDownload } from '../../../../lib/storage';
 import { inngest } from '../../../../jobs';
 
 export const config = { runtime: 'edge' };
 
-const prisma = new PrismaClient();
 
 const paramsSchema = z.object({ uploadId: z.string() });
 const bodySchema = z.object({ type: z.enum(['csv', 'html']) });

--- a/apps/web/src/pages/api/opal/upload.ts
+++ b/apps/web/src/pages/api/opal/upload.ts
@@ -1,11 +1,10 @@
 import { z } from 'zod';
 import { requireUser } from '../../../lib/auth';
 import { presignUpload } from '../../../lib/storage';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../../../lib/prisma';
 
 export const config = { runtime: 'edge' };
 
-const prisma = new PrismaClient();
 
 const bodySchema = z.object({ filename: z.string(), mime: z.string() });
 const responseSchema = z.object({ uploadId: z.string(), url: z.string() });


### PR DESCRIPTION
## Summary
- use shared prisma instance in Opal upload and parse API handlers
- add tests to verify PrismaClient is instantiated once across multiple requests

## Testing
- `npm test`
